### PR TITLE
Refactor date type into separate schema

### DIFF
--- a/schemas/bursar-export/tokens/bursarExportTokenCurrentDate.json
+++ b/schemas/bursar-export/tokens/bursarExportTokenCurrentDate.json
@@ -7,21 +7,7 @@
       "default": "Date"
     },
     "value": {
-      "type": "string",
-      "enum": [
-        "YEAR_LONG",
-        "YEAR_SHORT",
-        "MONTH",
-        "DATE",
-        "HOUR",
-        "MINUTE",
-        "SECOND",
-        "QUARTER",
-        "WEEK_OF_YEAR",
-        "WEEK_OF_YEAR_ISO",
-        "WEEK_YEAR",
-        "WEEK_YEAR_ISO"
-      ]
+      "$ref": "bursarExportTokenDateType.json"
     },
     "timezone": {
       "type": "string"

--- a/schemas/bursar-export/tokens/bursarExportTokenDateType.json
+++ b/schemas/bursar-export/tokens/bursarExportTokenDateType.json
@@ -1,0 +1,18 @@
+{
+  "description": "Schema to represent the type of date information",
+  "type": "string",
+  "enum": [
+    "YEAR_LONG",
+    "YEAR_SHORT",
+    "MONTH",
+    "DATE",
+    "HOUR",
+    "MINUTE",
+    "SECOND",
+    "QUARTER",
+    "WEEK_OF_YEAR",
+    "WEEK_OF_YEAR_ISO",
+    "WEEK_YEAR",
+    "WEEK_YEAR_ISO"
+  ]
+}

--- a/schemas/bursar-export/tokens/bursarExportTokenFeeDate.json
+++ b/schemas/bursar-export/tokens/bursarExportTokenFeeDate.json
@@ -11,21 +11,7 @@
       "enum": ["CREATED", "UPDATED", "DUE", "RETURNED"]
     },
     "value": {
-      "type": "string",
-      "enum": [
-        "YEAR_LONG",
-        "YEAR_SHORT",
-        "MONTH",
-        "DATE",
-        "HOUR",
-        "MINUTE",
-        "SECOND",
-        "QUARTER",
-        "WEEK_OF_YEAR",
-        "WEEK_OF_YEAR_ISO",
-        "WEEK_YEAR",
-        "WEEK_YEAR_ISO"
-      ]
+      "$ref": "bursarExportTokenDateType.json"
     },
     "placeholder": {
       "type": "string"


### PR DESCRIPTION
I made the date type into a separate schema so I can use it as a class in the worker. 